### PR TITLE
Remove drafts from relational responses

### DIFF
--- a/src/pages/blocks/[id].tsx
+++ b/src/pages/blocks/[id].tsx
@@ -1,6 +1,5 @@
 import axios from 'axios'
-import { BlockOneLevelDeep, Data } from '../../types'
-import { getBlocks } from '../../shared/requests/blocks/blocks'
+import { Block, BlockOneLevelDeep, Data } from '../../types'
 import {
   LearningMaterialContainer,
   LearningMaterialOverview,
@@ -11,6 +10,7 @@ import styled from '@emotion/styled'
 import LearningMaterial from '../../components/LearningMaterial'
 import { ReactMarkdown } from 'react-markdown/lib/react-markdown'
 import { handleBlockDocxDownload } from '../../utils/downloadAsDocx/downloadAsDocx'
+import { ResponseArray } from '../../shared/requests/types'
 
 const BlockContentWrapper = styled.div`
   margin-top: 5rem;
@@ -52,9 +52,11 @@ export async function getStaticPaths() {
     }
   }
 
-  const blocks = await getBlocks()
+  const blocks: ResponseArray<Block> = await axios.get(
+    `${process.env.STRAPI_API_URL}/blocks`
+  )
 
-  const paths = blocks.map((block) => ({
+  const paths = blocks.data.data.map((block) => ({
     params: { id: `${block.id}` },
   }))
 

--- a/src/pages/courses/[id].tsx
+++ b/src/pages/courses/[id].tsx
@@ -3,12 +3,13 @@ import axios from 'axios'
 import CardList from '../../components/CardList/CardList'
 import LearningMaterial from '../../components/LearningMaterial'
 import MetadataContainer from '../../components/MetadataContainer/MetadataContainer'
-import { getCourses } from '../../shared/requests/courses/courses'
+import { ResponseArray } from '../../shared/requests/types'
+import { filterOutOnlyPublishedEntriesOnCourse } from '../../shared/requests/utils/publishedEntriesFilter'
 import {
   LearningMaterialContainer,
   LearningMaterialOverview,
 } from '../../styles/global'
-import { CourseThreeLevelsDeep, Data } from '../../types'
+import { Course, CourseThreeLevelsDeep, Data } from '../../types'
 import { handleCourseDocxDownload } from '../../utils/downloadAsDocx/downloadAsDocx'
 import { summarizeDurations } from '../../utils/utils'
 
@@ -69,9 +70,11 @@ export async function getStaticPaths() {
     }
   }
 
-  const courses = await getCourses()
+  const courses: ResponseArray<Course> = await axios.get(
+    `${process.env.STRAPI_API_URL}/courses`
+  )
 
-  const paths = courses.map((course) => {
+  const paths = courses.data.data.map((course) => {
     return {
       params: { id: `${course.id}` },
     }
@@ -92,9 +95,9 @@ export async function getStaticProps(ctx: any) {
   const res = await axios.get(
     `${process.env.STRAPI_API_URL}/courses/${ctx.params.id}?${populateBlocks}&${populateCourseCreator}&${populateLectureCreator}&${populateLearningOutcomes}&${populateBlockAuthors}`
   )
-  const course = res.data.data
+  const course: Data<CourseThreeLevelsDeep> = res.data.data
 
   return {
-    props: { course },
+    props: { course: filterOutOnlyPublishedEntriesOnCourse(course) },
   }
 }

--- a/src/shared/requests/blocks/blocks.ts
+++ b/src/shared/requests/blocks/blocks.ts
@@ -1,15 +1,13 @@
 import axios from 'axios'
-import { Block, BlockOneLevelDeep } from '../../../types'
+import { BlockOneLevelDeep } from '../../../types'
 import { ResponseArray, ResponseArrayData } from '../types'
-import { FilterParameters, getAuthorsAndKeywordsFilterString } from '../utils'
+import {
+  FilterParameters,
+  getAuthorsAndKeywordsFilterString,
+} from '../utils/utils'
 
 const ENDPOINT = `${process.env.NEXT_PUBLIC_STRAPI_API_URL}/blocks`
 const DEFAULT_MATCHES_PER_PAGE = 10
-
-export const getBlocks = async () => {
-  const response: ResponseArray<Block> = await axios.get(ENDPOINT)
-  return response.data.data
-}
 
 export const filterBlockOnKeywordsAndAuthors = async ({
   keywords,

--- a/src/shared/requests/courses/courses.ts
+++ b/src/shared/requests/courses/courses.ts
@@ -1,22 +1,10 @@
 import axios from 'axios'
-import { getAuthorsAndKeywordsFilterString } from '../utils'
-import { Course, CourseThreeLevelsDeep } from '../../../types'
-import { Response, ResponseArray } from '../types'
+import { getAuthorsAndKeywordsFilterString } from '../utils/utils'
+import { CourseThreeLevelsDeep } from '../../../types'
+import { ResponseArray } from '../types'
 
 const ENDPOINT = `${process.env.NEXT_PUBLIC_STRAPI_API_URL}/courses`
 const DEFAULT_MATCHES_PER_PAGE = 10
-
-export const getCourses = async () => {
-  const response: ResponseArray<Course> = await axios.get(ENDPOINT)
-  return response.data.data
-}
-
-export const getCourseWithLecturesAndBlocks = async (courseId: string) => {
-  const response: Response<CourseThreeLevelsDeep> = await axios.get(
-    `${ENDPOINT}/${courseId}?populate[Lectures][populate][0]=Blocks`
-  )
-  return response.data.data
-}
 
 const getPopulateString = () => {
   const populateCourseCreator = 'populate[CourseCreator][populate]=*'

--- a/src/shared/requests/lectures/lectures.ts
+++ b/src/shared/requests/lectures/lectures.ts
@@ -1,15 +1,13 @@
 import axios from 'axios'
-import { Lecture, LectureTwoLevelsDeep } from '../../../types'
+import { LectureTwoLevelsDeep } from '../../../types'
 import { ResponseArray, ResponseArrayData } from '../types'
-import { FilterParameters, getAuthorsAndKeywordsFilterString } from '../utils'
+import {
+  FilterParameters,
+  getAuthorsAndKeywordsFilterString,
+} from '../utils/utils'
 
 const ENDPOINT = `${process.env.NEXT_PUBLIC_STRAPI_API_URL}/lectures`
 const DEFAULT_MATCHES_PER_PAGE = 10
-
-export const getLectures = async () => {
-  const response: ResponseArray<Lecture> = await axios.get(ENDPOINT)
-  return response.data.data
-}
 
 const getPopulateString = () => {
   const populateLectureCreator = 'populate[LectureCreator]=*'

--- a/src/shared/requests/utils/publishedEntriesFilter.ts
+++ b/src/shared/requests/utils/publishedEntriesFilter.ts
@@ -1,0 +1,56 @@
+import {
+  BlockOneLevelDeep,
+  CourseThreeLevelsDeep,
+  Data,
+  LectureTwoLevelsDeep,
+} from '../../../types'
+
+// The functions in this file are unfortunately needed, because Strapi's API doesn't filter out
+// published sub-relation, but instead returns every relation (published AND drafts)...
+// https://github.com/strapi/strapi/issues/12665
+
+export const filterOutOnlyPublishedEntriesOnCourse = (
+  course: Data<CourseThreeLevelsDeep>
+) => {
+  const filteredResult = filterOutOnlyPublishedEntriesOnCourses([course])
+  return filteredResult[0]
+}
+
+const filterOutOnlyPublishedEntriesOnCourses = (
+  courses: Data<CourseThreeLevelsDeep>[]
+) => {
+  return courses
+    .filter((course) => course.attributes.publishedAt !== null)
+    .map((course) => {
+      course.attributes.Lectures.data = filterOutOnlyPublishedEntriesOnLectures(
+        course.attributes.Lectures.data
+      )
+      return course
+    })
+}
+
+export const filterOutOnlyPublishedEntriesOnLecture = (
+  lecture: Data<LectureTwoLevelsDeep>
+) => {
+  const filteredResult = filterOutOnlyPublishedEntriesOnLectures([lecture])
+  return filteredResult[0]
+}
+
+const filterOutOnlyPublishedEntriesOnLectures = (
+  lectures: Data<LectureTwoLevelsDeep>[]
+) => {
+  return lectures
+    .filter((lecture) => lecture.attributes.publishedAt !== null)
+    .map((lecture) => {
+      lecture.attributes.Blocks.data = filterOutOnlyPublishedEntriesOnBlocks(
+        lecture.attributes.Blocks.data
+      )
+      return lecture
+    })
+}
+
+const filterOutOnlyPublishedEntriesOnBlocks = (
+  blocks: Data<BlockOneLevelDeep>[]
+) => {
+  return blocks.filter((block) => block.attributes.publishedAt !== null)
+}

--- a/src/shared/requests/utils/utils.ts
+++ b/src/shared/requests/utils/utils.ts
@@ -1,4 +1,4 @@
-import { LearningMaterialType } from '../../types'
+import { LearningMaterialType } from '../../../types'
 
 export type FilterParameters = {
   keywords: string[]


### PR DESCRIPTION
https://trello.com/c/pYuuYJay/130-prevent-non-published-versions-from-being-fetched

I've tested if this issue is a problem when filtering as well (so that it looks among drafts for matching filters), but luckily it doesn't (that would have forced us to write some really ugly code).

Also removed some redundant logic.