### PR TITLE
Make images dynamically fit inside slide

### DIFF
--- a/src/utils/createPptx/pptxConfiguration/image.ts
+++ b/src/utils/createPptx/pptxConfiguration/image.ts
@@ -1,6 +1,6 @@
 import PptxGenJS from 'pptxgenjs'
+import { getSlideHeadingWidth } from './slideElements'
 
-import { SLIDE_HEADING_WIDTH } from './slideElements'
 import {
   remainingHeight,
   SLIDE_WIDTH_HEIGHT_RATIO,
@@ -63,7 +63,9 @@ const generateImageProps = (images: Image[]): PptxGenJS.ImageProps[] => {
     return {
       altText: image.altText,
       path: image.path,
-      x: toPercentage(X_PADDING + SLIDE_HEADING_WIDTH + IMAGE_MARGIN_LEFT),
+      x: toPercentage(
+        X_PADDING + getSlideHeadingWidth(true) + IMAGE_MARGIN_LEFT
+      ),
       y: toPercentage(yPosition),
       w: toPercentage(image.dimensions.w),
       h: toPercentage(image.dimensions.h),

--- a/src/utils/createPptx/pptxConfiguration/image.ts
+++ b/src/utils/createPptx/pptxConfiguration/image.ts
@@ -1,16 +1,83 @@
 import PptxGenJS from 'pptxgenjs'
 
+import { SLIDE_HEADING_WIDTH } from './slideElements'
+import {
+  remainingHeight,
+  SLIDE_WIDTH_HEIGHT_RATIO,
+  toPercentage,
+  X_PADDING,
+  Y_PADDING,
+} from './utils'
+
+export type Image = {
+  dimensions: Dimensions
+  path: string
+  altText: string
+}
+
+type Dimensions = {
+  w: number
+  h: number
+}
+
 export const IMAGE_WIDTH = 30
 export const IMAGE_MARGIN_LEFT = 5
-export const ESTIMATED_REASONABLE_IMAGE_HEIGHT = 40
+export const IMAGE_Y_MARGIN = 5
 
-export const getBaseImageStyling = (
+export const getImageStyling = (
+  allImagesOnSlide: Image[]
+): PptxGenJS.ImageProps[] => {
+  const amountOfImages = allImagesOnSlide.length
+  const imagesTotalHeight = getAccumulatedImageHeight(allImagesOnSlide)
+  const allowedHeight = remainingHeight(
+    Y_PADDING * 2 + IMAGE_Y_MARGIN * (amountOfImages - 1)
+  )
+  const requiredScale = getImageScale(imagesTotalHeight, allowedHeight)
+  const imagesWithScaledDimensions: Image[] = allImagesOnSlide.map((image) => ({
+    ...image,
+    dimensions: {
+      w: requiredScale * image.dimensions.w,
+      h: requiredScale * image.dimensions.h,
+    },
+  }))
+
+  const newImageAttributesFittingSlide = generateImageProps(
+    imagesWithScaledDimensions
+  )
+
+  return newImageAttributesFittingSlide
+}
+
+const getImageScale = (imagesTotalHeight: number, allowedHeight: number) =>
+  Math.min(1, allowedHeight / imagesTotalHeight)
+
+const getAccumulatedImageHeight = (images: Image[]) =>
+  images.reduce((height, image) => (height += image.dimensions.h), 0)
+
+const generateImageProps = (images: Image[]): PptxGenJS.ImageProps[] => {
+  let occupiedHeight = Y_PADDING
+
+  return images.map((image) => {
+    const yPosition = occupiedHeight
+    occupiedHeight += IMAGE_Y_MARGIN + image.dimensions.h
+    return {
+      altText: image.altText,
+      path: image.path,
+      x: toPercentage(X_PADDING + SLIDE_HEADING_WIDTH + IMAGE_MARGIN_LEFT),
+      y: toPercentage(yPosition),
+      w: toPercentage(image.dimensions.w),
+      h: toPercentage(image.dimensions.h),
+    }
+  })
+}
+
+export const getImageDimensions = (
   width: number,
   height: number
-): PptxGenJS.ImageProps => {
+): Dimensions => {
   const aspectRatio = width / height
   const adjustedWidth = IMAGE_WIDTH
-  const adjustedHeight = IMAGE_WIDTH / aspectRatio
+  const adjustedHeight = (IMAGE_WIDTH / aspectRatio) * SLIDE_WIDTH_HEIGHT_RATIO
 
   return {
     w: adjustedWidth,

--- a/src/utils/createPptx/pptxConfiguration/mainContent.ts
+++ b/src/utils/createPptx/pptxConfiguration/mainContent.ts
@@ -1,13 +1,17 @@
 import PptxGenJS from 'pptxgenjs'
+import { IMAGE_MARGIN_LEFT, IMAGE_WIDTH } from './image'
 import {
   toPercentage,
   startXPos,
   X_PADDING,
   Y_PADDING,
   remainingHeight,
+  remainingWidth,
 } from './utils'
 
-const PRIMARY_CONTENT_WIDTH = 65
+const PRIMARY_CONTENT_WIDTH = remainingWidth(
+  2 * X_PADDING + IMAGE_WIDTH + IMAGE_MARGIN_LEFT
+)
 const ESTIMATED_SLIDE_TITLE_HEIGHT = 15
 export const PRIMARY_CONTENT_MARGIN_RIGHT = 2
 
@@ -30,5 +34,5 @@ const primaryContentStyling: PptxGenJS.TextPropsOptions = {
   ...commonConfiguration,
   x: startXPos,
   y: toPercentage(Y_PADDING + ESTIMATED_SLIDE_TITLE_HEIGHT),
-  w: toPercentage(PRIMARY_CONTENT_WIDTH - X_PADDING),
+  w: toPercentage(PRIMARY_CONTENT_WIDTH),
 }

--- a/src/utils/createPptx/pptxConfiguration/mainContent.ts
+++ b/src/utils/createPptx/pptxConfiguration/mainContent.ts
@@ -1,68 +1,20 @@
 import PptxGenJS from 'pptxgenjs'
-import { ESTIMATED_REASONABLE_IMAGE_HEIGHT } from './image'
 import {
   toPercentage,
   startXPos,
   X_PADDING,
   Y_PADDING,
   remainingHeight,
-  remainingWidth,
 } from './utils'
 
 const PRIMARY_CONTENT_WIDTH = 65
 const ESTIMATED_SLIDE_TITLE_HEIGHT = 15
-const PRIMARY_CONTENT_MARGIN_RIGHT = 2
-
-const NON_PRIMARY_CONTENT_START_X_POS =
-  X_PADDING + PRIMARY_CONTENT_WIDTH + PRIMARY_CONTENT_MARGIN_RIGHT
+export const PRIMARY_CONTENT_MARGIN_RIGHT = 2
 
 export type ListStyle = 'UNORDERED' | 'ORDERED'
-type BulletAttribute =
-  | true
-  | {
-      readonly type: 'number'
-    }
-  | undefined
 
 export const getPrimaryContentStyling = (): PptxGenJS.TextPropsOptions => {
   return primaryContentStyling
-}
-
-export const getSecondaryContentStyling = (
-  listStyle: ListStyle | undefined,
-  slideHasImage: boolean
-): PptxGenJS.TextPropsOptions => {
-  const baseYPos = Y_PADDING + ESTIMATED_SLIDE_TITLE_HEIGHT
-
-  // TODO the following could be made more dynamic once we start implementing the images
-  const yPos = slideHasImage
-    ? toPercentage(baseYPos + ESTIMATED_REASONABLE_IMAGE_HEIGHT)
-    : toPercentage(baseYPos)
-
-  return {
-    ...secondaryContentStyling,
-    bullet: getListConfig(listStyle),
-    y: yPos,
-  }
-}
-
-export const getFallbackContentStyling = (
-  listStyle: ListStyle | undefined
-): PptxGenJS.TextPropsOptions => {
-  return {
-    ...fallbackContentStyling,
-    bullet: getListConfig(listStyle),
-  }
-}
-
-const getListConfig = (listStyle?: ListStyle): BulletAttribute => {
-  if (listStyle === undefined) {
-    return undefined
-  }
-  const orderedListConfig = {
-    type: 'number',
-  } as const
-  return listStyle === 'UNORDERED' ? true : orderedListConfig
 }
 
 const commonConfiguration = {
@@ -79,18 +31,4 @@ const primaryContentStyling: PptxGenJS.TextPropsOptions = {
   x: startXPos,
   y: toPercentage(Y_PADDING + ESTIMATED_SLIDE_TITLE_HEIGHT),
   w: toPercentage(PRIMARY_CONTENT_WIDTH - X_PADDING),
-}
-
-const secondaryContentStyling: PptxGenJS.TextPropsOptions = {
-  ...commonConfiguration,
-  x: toPercentage(NON_PRIMARY_CONTENT_START_X_POS),
-  y: '50%',
-  w: toPercentage(remainingWidth(NON_PRIMARY_CONTENT_START_X_POS + X_PADDING)),
-}
-
-const fallbackContentStyling: PptxGenJS.TextPropsOptions = {
-  ...commonConfiguration,
-  x: toPercentage(NON_PRIMARY_CONTENT_START_X_POS),
-  y: '80%',
-  w: toPercentage(remainingWidth(NON_PRIMARY_CONTENT_START_X_POS + X_PADDING)),
 }

--- a/src/utils/createPptx/pptxConfiguration/slideElements.ts
+++ b/src/utils/createPptx/pptxConfiguration/slideElements.ts
@@ -8,11 +8,27 @@ import {
   startYPos,
 } from './utils'
 
-export const SLIDE_HEADING_WIDTH = remainingWidth(
+const SLIDE_HEADING_WIDTH = remainingWidth(
   2 * X_PADDING + IMAGE_WIDTH + IMAGE_MARGIN_LEFT
 )
 
-export const slideHeading: PptxGenJS.TextPropsOptions = {
+export const getSlideHeadingWidth = (slideContainsImage: boolean) => {
+  return slideContainsImage
+    ? remainingWidth(2 * X_PADDING + IMAGE_WIDTH + IMAGE_MARGIN_LEFT)
+    : remainingWidth(2 * X_PADDING)
+}
+
+export const getSlideHeading = (
+  slideContainsImage: boolean
+): PptxGenJS.TextPropsOptions => {
+  const headingWidth = getSlideHeadingWidth(slideContainsImage)
+  return {
+    ...slideHeading,
+    w: toPercentage(headingWidth),
+  }
+}
+
+const slideHeading: PptxGenJS.TextPropsOptions = {
   x: startXPos,
   y: startYPos,
   fontSize: 36,

--- a/src/utils/createPptx/pptxConfiguration/slideElements.ts
+++ b/src/utils/createPptx/pptxConfiguration/slideElements.ts
@@ -1,19 +1,14 @@
 import PptxGenJS from 'pptxgenjs'
-import {
-  ESTIMATED_REASONABLE_IMAGE_HEIGHT,
-  IMAGE_MARGIN_LEFT,
-  IMAGE_WIDTH,
-} from './image'
+import { IMAGE_MARGIN_LEFT, IMAGE_WIDTH } from './image'
 import {
   remainingWidth,
   toPercentage,
   startXPos,
   X_PADDING,
   startYPos,
-  Y_PADDING,
 } from './utils'
 
-const SLIDE_HEADING_WIDTH = remainingWidth(
+export const SLIDE_HEADING_WIDTH = remainingWidth(
   2 * X_PADDING + IMAGE_WIDTH + IMAGE_MARGIN_LEFT
 )
 
@@ -51,18 +46,6 @@ export const h3Heading: PptxGenJS.TextPropsOptions = {
   w: '90%',
   h: 0.75,
   autoFit: true,
-}
-
-export const imageStyling: PptxGenJS.ImageProps = {
-  x: toPercentage(X_PADDING + SLIDE_HEADING_WIDTH),
-  y: startYPos,
-  w: '25%',
-  h: '30%',
-  sizing: {
-    type: 'contain',
-    w: toPercentage(remainingWidth(X_PADDING * 2 + SLIDE_HEADING_WIDTH)),
-    h: toPercentage(Y_PADDING + ESTIMATED_REASONABLE_IMAGE_HEIGHT),
-  },
 }
 
 export const citeAsStyling: PptxGenJS.TextPropsOptions = {

--- a/src/utils/createPptx/pptxConfiguration/utils.ts
+++ b/src/utils/createPptx/pptxConfiguration/utils.ts
@@ -1,6 +1,12 @@
 export const X_PADDING = 3
 export const Y_PADDING = 10
 
+// https://gitbrent.github.io/PptxGenJS/docs/usage-pres-options/#standard-slide-layouts
+const SLIDE_WIDTH_IN_INCHES = 10
+const SLIDE_HEIGHT_IN_INCHES = 5.625
+export const SLIDE_WIDTH_HEIGHT_RATIO =
+  SLIDE_WIDTH_IN_INCHES / SLIDE_HEIGHT_IN_INCHES
+
 export const remainingWidth = (width: number): number => {
   return hundredRemains(width)
 }

--- a/src/utils/createPptx/utils/getSlides.ts
+++ b/src/utils/createPptx/utils/getSlides.ts
@@ -1,20 +1,15 @@
 import PptxGenJS from 'pptxgenjs'
-import { imageStyling } from '../pptxConfiguration/slideElements'
 import { PptxSlide } from '../../../types/pptx'
 
 const getSlides = (blockSlides: PptxSlide[], pptx: PptxGenJS) => {
   return blockSlides.map((pptxSlide) => {
     const contentSlide = pptx.addSlide()
 
-    //Headings
     contentSlide.addText(`${pptxSlide.heading}`, pptxSlide.headingStyling)
 
     if (pptxSlide?.images !== undefined && pptxSlide?.images.length > 0) {
       for (const image of pptxSlide.images) {
-        contentSlide.addImage({
-          ...imageStyling,
-          ...image,
-        })
+        contentSlide.addImage(image)
       }
     }
 

--- a/src/utils/downloadAsPptx/markdownToSlideFormat.ts
+++ b/src/utils/downloadAsPptx/markdownToSlideFormat.ts
@@ -4,7 +4,7 @@ import PptxGenJS from 'pptxgenjs'
 
 import { getImageMetadata, sourceIsFromS3, stripBackslashN } from '../utils'
 import { Slide } from '../../types'
-import { slideHeading } from '../createPptx/pptxConfiguration/slideElements'
+import { getSlideHeading } from '../createPptx/pptxConfiguration/slideElements'
 import { PptxSlide } from '../../types/pptx'
 import { getPrimaryContentStyling } from '../createPptx/pptxConfiguration/mainContent'
 import {
@@ -180,7 +180,9 @@ const markdownToSlideFormat = async (slide: Slide): Promise<PptxSlide> => {
   }
 
   pptxSlide.heading = slideTitle ?? ''
-  pptxSlide.headingStyling = slideHeading
+  pptxSlide.headingStyling = getSlideHeading(
+    pptxSlide.images !== undefined && pptxSlide.images.length > 0
+  )
   pptxSlide.title = slideTitle ?? ''
 
   return pptxSlide

--- a/src/utils/downloadAsPptx/markdownToSlideFormat.ts
+++ b/src/utils/downloadAsPptx/markdownToSlideFormat.ts
@@ -14,7 +14,11 @@ import {
   listItemStyle,
   paragraphStyle,
 } from '../createPptx/pptxConfiguration/text'
-import { getBaseImageStyling } from '../createPptx/pptxConfiguration/image'
+import {
+  Image,
+  getImageDimensions,
+  getImageStyling,
+} from '../createPptx/pptxConfiguration/image'
 
 type TokenWithoutTextField =
   | marked.Tokens.Space
@@ -69,7 +73,7 @@ const markdownToSlideFormat = async (slide: Slide): Promise<PptxSlide> => {
     async (finalSlide, slideValue, index) => {
       const slideAttribute = {} as PptxSlide
       const mainSlideContent = [] as PptxGenJS.TextProps[]
-      const images = [] as PptxGenJS.ImageProps[]
+      const images = [] as Image[]
 
       // Ignore id (first index) and speaker notes (last index)
       if (index === 0 || index === Object.values(slide).length - 1) {
@@ -92,14 +96,14 @@ const markdownToSlideFormat = async (slide: Slide): Promise<PptxSlide> => {
           if (imageToken !== undefined && sourceIsFromS3(imageToken.href)) {
             const href = `${imageToken.href}?do-not-fetch-from-cache`
             const image = await getImageMetadata(href)
-            const imageStyling = getBaseImageStyling(
+            const imageDimensions = getImageDimensions(
               image.naturalWidth,
               image.naturalHeight
             )
             images.push({
+              dimensions: imageDimensions,
               path: href,
               altText: imageToken.text,
-              ...imageStyling,
             })
           }
 
@@ -159,7 +163,7 @@ const markdownToSlideFormat = async (slide: Slide): Promise<PptxSlide> => {
       }
 
       slideAttribute.mainContent = mainSlideContent
-      slideAttribute.images = images
+      slideAttribute.images = getImageStyling(images)
 
       return Promise.resolve({
         ...finalSlide,


### PR DESCRIPTION
Takes all images in the slide into account, and scales their height (indirectly width as well since we preserve the aspect ratio) so all images can fit inside the same slide. The images are separated by a margin.