### PR TITLE
Feature/markdown features

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,7 @@
 // if you use a type/interface in more than one place it goes into the ~src/types/index.d.ts file
 // if you extend a type/interface, it can be declared locally, but as long as it doesn't get used more than once
 
-type Modify<T, R> = Omit<T, keyof R> & R
+export type Modify<T, R> = Omit<T, keyof R> & R
 
 export type Data<T> = {
   id: number

--- a/src/utils/createPptx/pptxConfiguration/mainContent.ts
+++ b/src/utils/createPptx/pptxConfiguration/mainContent.ts
@@ -27,7 +27,6 @@ export const getPrimaryContentStyling = (): PptxGenJS.TextPropsOptions => {
 
 const commonConfiguration = {
   autoFit: true,
-  breakLine: true,
   valign: 'top' as const,
   h: toPercentage(
     remainingHeight(2 * Y_PADDING + ESTIMATED_SLIDE_TITLE_HEIGHT)

--- a/src/utils/createPptx/pptxConfiguration/text.ts
+++ b/src/utils/createPptx/pptxConfiguration/text.ts
@@ -1,32 +1,49 @@
 import PptxGenJS from 'pptxgenjs'
 
-const commonConfiguration: PptxGenJS.TextPropsOptions = {
+type TextProps = PptxGenJS.TextPropsOptions
+
+const commonConfiguration: TextProps = {
   bullet: false,
   indentLevel: 0,
+  breakLine: false,
 }
 
-export const paragraphStyle: PptxGenJS.TextPropsOptions = {
+const commonParagraphConfiguration: TextProps = {
   ...commonConfiguration,
   fontSize: 18,
 }
 
-export const listItemStyle: PptxGenJS.TextPropsOptions = {
+export const paragraphStyle: TextProps = {
+  ...commonParagraphConfiguration,
+}
+
+export const strongStyle: TextProps = {
+  ...commonParagraphConfiguration,
+  bold: true,
+}
+
+export const italicStyle: TextProps = {
+  ...commonParagraphConfiguration,
+  italic: true,
+}
+
+export const listItemStyle: TextProps = {
   fontSize: 18,
 }
 
-export const h1Style: PptxGenJS.TextPropsOptions = {
+export const h1Style: TextProps = {
   ...commonConfiguration,
   fontSize: 26,
   bold: true,
 }
 
-export const h2Style: PptxGenJS.TextPropsOptions = {
+export const h2Style: TextProps = {
   ...commonConfiguration,
   fontSize: 22,
   bold: true,
 }
 
-export const h3Style: PptxGenJS.TextPropsOptions = {
+export const h3Style: TextProps = {
   ...commonConfiguration,
   fontSize: 18,
   bold: true,

--- a/src/utils/createPptx/pptxConfiguration/text.ts
+++ b/src/utils/createPptx/pptxConfiguration/text.ts
@@ -27,6 +27,13 @@ export const italicStyle: TextProps = {
   italic: true,
 }
 
+export const underlineStyle: TextProps = {
+  ...commonParagraphConfiguration,
+  underline: {
+    style: 'heavy',
+  },
+}
+
 export const listItemStyle: TextProps = {
   fontSize: 18,
 }

--- a/src/utils/downloadAsDocx/downloadAsDocx.ts
+++ b/src/utils/downloadAsDocx/downloadAsDocx.ts
@@ -84,7 +84,6 @@ export const handleBlockDocxDownload = async (
       downloadConfiguration,
       footer
     )
-    console.log(blob.size)
 
     saveAs(blob, `${block.attributes.Title}.docx`)
   } catch (error) {


### PR DESCRIPTION
As. you can tell, the way to parse underline was a bit cumbersome, since Marked doesn't seem to recognize underline in the same way as other nodes. Other nodes get their type like `type: italics`, while underline gets type: text, but it's surrounding nodes are `<u>` and `</u>`...

Tell me if you see any way to improve this.