### PR TITLE
Fix better type check for lecture blocks

### DIFF
--- a/src/types/checkers.ts
+++ b/src/types/checkers.ts
@@ -9,7 +9,7 @@ import {
 export const isBlockOneLevelDeep = (
   data: Data<DownloadableContent>
 ): data is Data<BlockOneLevelDeep> =>
-  !!(data as Data<BlockOneLevelDeep>).attributes.Document
+  !!(data as Data<BlockOneLevelDeep>).attributes.Slides
 export const isLectureTwoLevelsDeep = (
   data: Data<DownloadableContent>
 ): data is Data<LectureTwoLevelsDeep> =>

--- a/src/utils/downloadAsPptx/downloadAsPptx.ts
+++ b/src/utils/downloadAsPptx/downloadAsPptx.ts
@@ -70,8 +70,10 @@ export const getContentSize = async (
       pptx.map(async (p) => ((await p.write()) as Blob).size)
     )
     size = blobSizes.reduce((total, blob) => total + blob, 0)
-  } else {
+  } else if (pptx) {
     size = ((await pptx?.write()) as Blob).size
+  } else {
+    return ''
   }
 
   const isBig = size > 10 ** 6


### PR DESCRIPTION
Still not ideal, but the Slides array will always be there, unlike the Document field