### PR TITLE
Add fallback locale fetch when content is unavailable. Add revalidate…

### DIFF
--- a/src/pages/blocks/[vuid].tsx
+++ b/src/pages/blocks/[vuid].tsx
@@ -91,8 +91,9 @@ export async function getStaticProps(ctx: GetStaticPropsContext) {
     const blockVuid = await axios.get(
       `${process.env.STRAPI_API_URL}/blockByVuid/${ctx.params?.vuid}?locale=${
         ctx.locale ?? ctx.defaultLocale
-      }`
+      }&fallbackToDefaultLocale=true`
     )
+
     const blockResponse = await axios.get(
       `${process.env.STRAPI_API_URL}/blocks/${blockVuid.data?.id}?populate=*`
     )
@@ -106,6 +107,7 @@ export async function getStaticProps(ctx: GetStaticPropsContext) {
 
     return {
       props: { block: filterOutOnlyPublishedEntriesOnBlock(block) },
+      revalidate: 60,
     }
   } catch (error) {
     return {

--- a/src/pages/courses/[vuid].tsx
+++ b/src/pages/courses/[vuid].tsx
@@ -103,7 +103,9 @@ export async function getStaticPaths() {
 export async function getStaticProps(ctx: GetStaticPropsContext) {
   try {
     const blockVuid = await axios.get(
-      `${process.env.STRAPI_API_URL}/courseByVuid/${ctx.params?.vuid}`
+      `${process.env.STRAPI_API_URL}/courseByVuid/${ctx.params?.vuid}?locale=${
+        ctx.locale ?? ctx.defaultLocale
+      }&fallbackToDefaultLocale=true`
     )
 
     const populateBlocks = 'populate[Lectures][populate][0]=Blocks'
@@ -126,6 +128,7 @@ export async function getStaticProps(ctx: GetStaticPropsContext) {
 
     return {
       props: { course: filterOutOnlyPublishedEntriesOnCourse(course) },
+      revalidate: 60,
     }
   } catch (error) {
     return {

--- a/src/pages/lectures/[vuid].tsx
+++ b/src/pages/lectures/[vuid].tsx
@@ -108,7 +108,7 @@ export async function getStaticProps(ctx: GetStaticPropsContext) {
     const lectureVuid = await axios.get(
       `${process.env.STRAPI_API_URL}/lectureByVuid/${ctx.params?.vuid}?locale=${
         ctx.locale ?? ctx.defaultLocale
-      }`
+      }&fallbackToDefaultLocale=true`
     )
 
     const populateCourses = 'populate[Courses]=*'
@@ -128,6 +128,7 @@ export async function getStaticProps(ctx: GetStaticPropsContext) {
       props: {
         lecture: filterOutOnlyPublishedEntriesOnLecture(lecture),
       },
+      revalidate: 60,
     }
   } catch (error) {
     return {


### PR DESCRIPTION
…: 60sec


The fallback is necessary in cases where the translated version is not available. In those cases we want to show the english (default) version instead of a 404 page.
(It's weird, because I can swear this kind of fallback happened automatically before, but I can't get it to work now, and not find anything online on it either.

Furthermore, on-demand ISR doesn't seem to have support on locale-entries, so those kind of updates will not be shown instantly. Instead, I added the revalidate field. So the paths will be updated once every minute. This made Amplify crash, but it should work on Vercel (works locally). Since Vercel is free for us, I couldn't find any reason to increase the revalidate timing interval.

NOT to be merged before https://github.com/ClimateCompatibleGrowth/teaching-kit-backend/pull/19