### PR TITLE
Add temporary style to language picker for mobile

### DIFF
--- a/src/components/Dropdown/styles.ts
+++ b/src/components/Dropdown/styles.ts
@@ -1,13 +1,7 @@
 import styled from '@emotion/styled'
 import { InputHTMLAttributes } from 'react'
 import { ubuntu } from '../../styles/fonts'
-import {
-  Accent40,
-  Background,
-  ButtonWithoutDefaultStyle,
-  mq,
-  UlWithoutDefaultStyle,
-} from '../../styles/global'
+import { Accent40, mq, UlWithoutDefaultStyle } from '../../styles/global'
 
 type IconButtonProps = {
   isPointingDown: boolean

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -35,30 +35,32 @@ export default function Navbar() {
               Teaching Material
             </Link>
           </Styled.Li>
-          <Styled.LanguageSelector>
-            {setLocale !== undefined && !isLoading ? (
-              <Dropdown
-                id='locale-selector'
-                enableSearch={false}
-                isSingleSelectable
-                selectedItems={[
-                  { id: locale, label: localeToLanguage(locale) },
-                ]}
-                setSelectedItems={(item) => setLocale(item[0].id as Locale)}
-                label='Choose language'
-                placeholder={localeToLanguage(locale)}
-                ariaLabel='Languages to pick from'
-                getItems={() =>
-                  Promise.resolve(
-                    locales.map((locale) => ({
-                      id: locale,
-                      label: localeToLanguage(locale),
-                    }))
-                  )
-                }
-              />
-            ) : null}
-          </Styled.LanguageSelector>
+          <Styled.Li>
+            <Styled.LanguageSelector>
+              {setLocale !== undefined && !isLoading ? (
+                <Dropdown
+                  id='locale-selector'
+                  enableSearch={false}
+                  isSingleSelectable
+                  selectedItems={[
+                    { id: locale, label: localeToLanguage(locale) },
+                  ]}
+                  setSelectedItems={(item) => setLocale(item[0].id as Locale)}
+                  label='Choose language'
+                  placeholder={localeToLanguage(locale)}
+                  ariaLabel='Languages to pick from'
+                  getItems={() =>
+                    Promise.resolve(
+                      locales.map((locale) => ({
+                        id: locale,
+                        label: localeToLanguage(locale),
+                      }))
+                    )
+                  }
+                />
+              ) : null}
+            </Styled.LanguageSelector>
+          </Styled.Li>
         </Styled.Ul>
       </Styled.Wrapper>
     </Styled.ColorBar>

--- a/src/components/Navbar/styles.ts
+++ b/src/components/Navbar/styles.ts
@@ -38,24 +38,35 @@ export const LogoWrapper = styled.div`
 `
 
 export const Ul = styled.ul`
-  padding: 0;
   margin: 0;
+  padding: 1rem 0;
 
   display: flex;
   list-style: none;
   justify-content: center;
+  flex-wrap: wrap;
+
+  ${mq.sm} {
+    padding: 0;
+  }
 `
 
 export const Li = styled.li`
   height: max-content;
 
   margin: auto 0;
+  padding: 1rem 0;
 
   color: ${Accent40};
   font-size: 1.4rem;
 
   ${mq.sm} {
     font-size: 1.8rem;
+    padding: 0;
+  }
+
+  ${mq.md} {
+    padding: 0;
   }
 
   a {
@@ -84,5 +95,4 @@ export const Li = styled.li`
 
 export const LanguageSelector = styled.div`
   margin: auto 0;
-  margin-left: 10rem;
 `

--- a/src/components/RecentUpdates/RecentUpdate/styles.ts
+++ b/src/components/RecentUpdates/RecentUpdate/styles.ts
@@ -29,8 +29,10 @@ export const Markdown = styled.div`
   -webkit-line-clamp: 6;
   -webkit-box-orient: vertical;
   white-space: normal;
+  margin-top: 1.6rem;
   margin-bottom: 1.6rem;
   p {
+    display: inline;
     strong {
       font-family: ${montserrat[500].style.fontFamily};
     }

--- a/src/components/RecentUpdates/RecentUpdates.tsx
+++ b/src/components/RecentUpdates/RecentUpdates.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { useRecentUpdates } from '../../hooks/useRecentUpdates'
-import { Accent40, PageContainer } from '../../styles/global'
+import { PageContainer } from '../../styles/global'
 import Button from '../Button/Button'
 import ButtonLink from '../ButtonLink/ButtonLink'
 import RecentUpdate from './RecentUpdate/RecentUpdate'

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -44,16 +44,16 @@ export const AccentYellow = '#F3F5B4'
 export const AccentYellowDarker = '#6E7113'
 
 export const breakpoints = {
-  xs: '480px',
-  sm: '768px',
-  md: '1024px',
-  lg: '1440px',
+  xs: '480px' as const,
+  sm: '768px' as const,
+  md: '1024px' as const,
+  lg: '1440px' as const,
 }
 export const mq = {
-  xs: `@media (min-width: ${breakpoints.xs})`,
-  sm: `@media (min-width: ${breakpoints.sm})`,
-  md: `@media (min-width: ${breakpoints.md})`,
-  lg: `@media (min-width: ${breakpoints.lg})`,
+  xs: `@media (min-width: ${breakpoints.xs})` as const,
+  sm: `@media (min-width: ${breakpoints.sm})` as const,
+  md: `@media (min-width: ${breakpoints.md})` as const,
+  lg: `@media (min-width: ${breakpoints.lg})` as const,
 }
 
 export const BorderRadius = '0.5rem'


### PR DESCRIPTION
The language picker stretched outside of the navbar width on mobile. I just put it on a new line on mobile for now (it will get its styling totally changed with https://trello.com/c/GxvklqS3/200-change-locale-dropdown-to-match-the-design)