### PR TITLE
Broken link from "Recently added content" on home page

### DIFF
--- a/src/components/RecentUpdates/RecentUpdates.tsx
+++ b/src/components/RecentUpdates/RecentUpdates.tsx
@@ -34,7 +34,9 @@ const RecentUpdates = ({
     setUpdatesToShow(updatesToShow + UPDATE_INCREMENTS)
   }
 
-  const updatesToRender = recentUpdates?.slice(0, updatesToShow)
+  const updatesToRender = recentUpdates
+    ?.slice(0, updatesToShow)
+    .filter((update) => update.Type === 'COURSE')
 
   return (
     <PageContainer hasBottomPadding hasSmallSidePadding>


### PR DESCRIPTION
closes #175 

**What was changed?**

* Display only courses in the "recently added content" section as suggested"