### PR TITLE
adds basic cookie consent and GA4

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,12 +7,12 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
-  
+
   // Increase body size limit for file uploads
   experimental: {
     serverComponentsExternalPackages: [],
   },
-  
+
   // Configure API routes to handle larger file uploads
   api: {
     bodyParser: {
@@ -40,9 +40,9 @@ const nextConfig = {
     contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
     remotePatterns: [
       {
-        protocol: 'http',  
-        hostname: '20.91.139.244',  
-        port: '1337', 
+        protocol: 'http',
+        hostname: '20.91.139.244',
+        port: '1337',
         pathname: '/**',
       },
       {

--- a/src/components/CookieConsent/CookieConsent.tsx
+++ b/src/components/CookieConsent/CookieConsent.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState, useContext } from 'react'
+import { LocaleContext } from '../../contexts/LocaleContext'
+import * as Styled from './styles'
+import { translations } from './translations'
+
+const COOKIE_CONSENT_KEY = 'cookie-consent'
+
+type ConsentValue = 'accepted' | 'declined' | null
+
+const CookieConsent = () => {
+  const { locale } = useContext(LocaleContext)
+  const [consent, setConsent] = useState<ConsentValue>(null)
+  const [isVisible, setIsVisible] = useState(false)
+
+  useEffect(() => {
+    // Check if user has already made a choice
+    const storedConsent = localStorage.getItem(COOKIE_CONSENT_KEY)
+    if (storedConsent) {
+      setConsent(storedConsent as ConsentValue)
+      setIsVisible(false)
+    } else {
+      setIsVisible(true)
+    }
+  }, [])
+
+  const handleAccept = () => {
+    localStorage.setItem(COOKIE_CONSENT_KEY, 'accepted')
+    setConsent('accepted')
+    setIsVisible(false)
+    // Here you can trigger GA4 initialization
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('cookieConsentAccepted'))
+    }
+  }
+
+  const handleDecline = () => {
+    localStorage.setItem(COOKIE_CONSENT_KEY, 'declined')
+    setConsent('declined')
+    setIsVisible(false)
+    // Here you can ensure GA4 is not initialized
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new CustomEvent('cookieConsentDeclined'))
+    }
+  }
+
+  if (!isVisible) {
+    return null
+  }
+
+  const t = translations[locale] || translations.en
+
+  return (
+    <Styled.Overlay>
+      <Styled.Banner>
+        <Styled.Content>
+          <Styled.Title>{t.title}</Styled.Title>
+          <Styled.Description>{t.description}</Styled.Description>
+        </Styled.Content>
+        <Styled.ButtonGroup>
+          <Styled.AcceptButton onClick={handleAccept}>
+            {t.accept}
+          </Styled.AcceptButton>
+          <Styled.DeclineButton onClick={handleDecline}>
+            {t.decline}
+          </Styled.DeclineButton>
+        </Styled.ButtonGroup>
+      </Styled.Banner>
+    </Styled.Overlay>
+  )
+}
+
+export default CookieConsent

--- a/src/components/CookieConsent/styles.ts
+++ b/src/components/CookieConsent/styles.ts
@@ -1,0 +1,129 @@
+import styled from '@emotion/styled'
+import {
+  Accent40,
+  OnAccent40,
+  Background,
+  Neutral40,
+  OnNeutral40,
+  mq,
+} from '../../styles/global'
+
+export const Overlay = styled.div`
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 9999;
+  background: rgba(0, 0, 0, 0.5);
+  padding: 1rem;
+  animation: fadeIn 0.3s ease-in-out;
+
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+`
+
+export const Banner = styled.div`
+  background: ${Background};
+  border-radius: 8px;
+  padding: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+
+  ${mq.md} {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 2rem;
+  }
+`
+
+export const Content = styled.div`
+  flex: 1;
+`
+
+export const Title = styled.h3`
+  margin: 0 0 0.5rem 0;
+  font-size: 1.8rem;
+  color: #242424;
+
+  ${mq.sm} {
+    font-size: 2rem;
+  }
+`
+
+export const Description = styled.p`
+  margin: 0;
+  font-size: 1.4rem;
+  line-height: 1.6;
+  color: #424242;
+
+  ${mq.sm} {
+    font-size: 1.6rem;
+  }
+`
+
+export const ButtonGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+
+  ${mq.sm} {
+    flex-direction: row;
+    width: auto;
+  }
+`
+
+const BaseButton = styled.button`
+  padding: 1.2rem 2.4rem;
+  font-size: 1.6rem;
+  font-weight: 600;
+  border-radius: 4px;
+  border: none;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  white-space: nowrap;
+  min-width: 140px;
+
+  &:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+
+  &:focus {
+    outline: 2px solid ${Accent40};
+    outline-offset: 2px;
+  }
+`
+
+export const AcceptButton = styled(BaseButton)`
+  background: ${Accent40};
+  color: ${OnAccent40};
+
+  &:hover {
+    background: #013080;
+  }
+`
+
+export const DeclineButton = styled(BaseButton)`
+  background: ${Neutral40};
+  color: ${OnNeutral40};
+
+  &:hover {
+    background: #5a5a5a;
+  }
+`

--- a/src/components/CookieConsent/translations.ts
+++ b/src/components/CookieConsent/translations.ts
@@ -1,0 +1,25 @@
+import { Locale } from '../../types'
+
+type CookieConsentTranslations = {
+  title: string
+  description: string
+  accept: string
+  decline: string
+}
+
+export const translations: Record<Locale, CookieConsentTranslations> = {
+  en: {
+    title: 'Cookie Consent',
+    description:
+      'We use cookies to collect visitor statistics with Google Analytics (GA4). This helps us improve the website and understand how it is used. You can choose to accept or decline cookies.',
+    accept: 'Accept',
+    decline: 'Decline',
+  },
+  sv: {
+    title: 'Cookiesamtycke',
+    description:
+      'Vi använder cookies för att samla in besöksstatistik med Google Analytics (GA4). Detta hjälper oss att förbättra webbplatsen och förstå hur den används. Du kan välja att tillåta eller avböja cookies.',
+    accept: 'Tillåt',
+    decline: 'Avböj',
+  },
+}

--- a/src/components/CookieConsent/translations.ts
+++ b/src/components/CookieConsent/translations.ts
@@ -15,11 +15,18 @@ export const translations: Record<Locale, CookieConsentTranslations> = {
     accept: 'Accept',
     decline: 'Decline',
   },
-  sv: {
-    title: 'Cookiesamtycke',
+  'es-ES': {
+    title: 'Consentimiento de cookies',
     description:
-      'Vi använder cookies för att samla in besöksstatistik med Google Analytics (GA4). Detta hjälper oss att förbättra webbplatsen och förstå hur den används. Du kan välja att tillåta eller avböja cookies.',
-    accept: 'Tillåt',
-    decline: 'Avböj',
+      'Utilizamos cookies para recopilar estadísticas de visitantes con Google Analytics (GA4). Esto nos ayuda a mejorar el sitio web y comprender cómo se utiliza. Puede elegir aceptar o rechazar las cookies.',
+    accept: 'Aceptar',
+    decline: 'Rechazar',
+  },
+  'fr-FR': {
+    title: 'Consentement aux cookies',
+    description:
+      "Nous utilisons des cookies pour collecter des statistiques de visiteurs avec Google Analytics (GA4). Cela nous aide à améliorer le site Web et à comprendre comment il est utilisé. Vous pouvez choisir d'accepter ou de refuser les cookies.",
+    accept: 'Accepter',
+    decline: 'Refuser',
   },
 }

--- a/src/components/GoogleAnalytics/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics/GoogleAnalytics.tsx
@@ -1,0 +1,59 @@
+import { useEffect } from 'react'
+import Script from 'next/script'
+import { areCookiesAccepted } from '../../utils/cookieConsent'
+
+const GA_MEASUREMENT_ID = 'G-J13MD2JZEM'
+
+declare global {
+  interface Window {
+    dataLayer: any[]
+    gtag: (...args: any[]) => void
+  }
+}
+
+const GoogleAnalytics = () => {
+  const shouldLoadGA = areCookiesAccepted()
+
+  useEffect(() => {
+    // Listen for consent events
+    const handleConsentAccepted = () => {
+      // Reload the page to initialize GA4
+      window.location.reload()
+    }
+
+    window.addEventListener('cookieConsentAccepted', handleConsentAccepted)
+
+    return () => {
+      window.removeEventListener('cookieConsentAccepted', handleConsentAccepted)
+    }
+  }, [])
+
+  if (!shouldLoadGA) {
+    return null
+  }
+
+  return (
+    <>
+      <Script
+        strategy='afterInteractive'
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+      />
+      <Script
+        id='google-analytics'
+        strategy='afterInteractive'
+        dangerouslySetInnerHTML={{
+          __html: `
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', '${GA_MEASUREMENT_ID}', {
+              page_path: window.location.pathname,
+            });
+          `,
+        }}
+      />
+    </>
+  )
+}
+
+export default GoogleAnalytics

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,8 @@
 import type { AppProps } from 'next/app'
 import Navbar from '../components/Navbar/Navbar'
 import Footer from '../components/Footer/Footer'
+import CookieConsent from '../components/CookieConsent/CookieConsent'
+import GoogleAnalytics from '../components/GoogleAnalytics/GoogleAnalytics'
 import { Global } from '@emotion/react'
 import defaultStyle from '../styles/default'
 import { LocaleProvider } from '../contexts/LocaleContext'
@@ -10,9 +12,11 @@ export default function App({ Component, pageProps }: AppProps) {
     <>
       <LocaleProvider>
         <Global styles={defaultStyle} />
+        <GoogleAnalytics />
         <Navbar />
         <Component {...pageProps} />
         <Footer />
+        <CookieConsent />
       </LocaleProvider>
     </>
   )

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,7 +45,7 @@ export type AuthorOneLevelDeep = Author & {
 }
 
 export const learningMaterialTypes = ['COURSE', 'LECTURE'] as const
-export type LearningMaterialType = typeof learningMaterialTypes[number]
+export type LearningMaterialType = (typeof learningMaterialTypes)[number]
 
 export type Keyword = {
   Keyword: string
@@ -143,10 +143,10 @@ export type CourseThreeLevelsDeepWithThreeLevelsDeepLocalizations = Modify<
 >
 
 export const LOCALES = ['en', 'es-ES', 'fr-FR'] as const
-export type Locale = typeof LOCALES[number]
+export type Locale = (typeof LOCALES)[number]
 
 export const LANGUAGES = ['English', 'Español', 'Français'] as const
-export type Language = typeof LANGUAGES[number]
+export type Language = (typeof LANGUAGES)[number]
 
 export type Path = {
   params: {
@@ -157,42 +157,44 @@ export type Path = {
 
 export type MediaFile = {
   data: Data<{
-    alternativeText: null | string,
-    caption: null | string,
-    createdAt: string,
-    ext: string,
-    hash: string,
-    height: number | null,
-    mime: string,
-    name: string,
-    previewUrl: string | null,
-    provider: string | null,
-    provider_metadata: null,
-    size: number,
-    updatedAt: string | null,
-    url: string,
+    alternativeText: null | string
+    caption: null | string
+    createdAt: string
+    ext: string
+    hash: string
+    height: number | null
+    mime: string
+    name: string
+    previewUrl: string | null
+    provider: string | null
+    provider_metadata: null
+    size: number
+    updatedAt: string | null
+    url: string
     width: number | null
   }> | null
 }
 
 export type MediaFiles = {
-  data: Data<{
-    alternativeText: null | string,
-    caption: null | string,
-    createdAt: string,
-    ext: string,
-    hash: string,
-    height: number | null,
-    mime: string,
-    name: string,
-    previewUrl: string | null,
-    provider: string | null,
-    provider_metadata: null,
-    size: number,
-    updatedAt: string | null,
-    url: string,
-    width: number | null
-  }>[] | null
+  data:
+    | Data<{
+        alternativeText: null | string
+        caption: null | string
+        createdAt: string
+        ext: string
+        hash: string
+        height: number | null
+        mime: string
+        name: string
+        previewUrl: string | null
+        provider: string | null
+        provider_metadata: null
+        size: number
+        updatedAt: string | null
+        url: string
+        width: number | null
+      }>[]
+    | null
 }
 
 type Image = {

--- a/src/utils/cookieConsent.ts
+++ b/src/utils/cookieConsent.ts
@@ -1,0 +1,28 @@
+/**
+ * Check if the user has given cookie consent
+ * @returns 'accepted' | 'declined' | null (null if no choice has been made)
+ */
+export const getCookieConsent = (): 'accepted' | 'declined' | null => {
+  if (typeof window === 'undefined') {
+    return null
+  }
+  const consent = localStorage.getItem('cookie-consent')
+  return consent as 'accepted' | 'declined' | null
+}
+
+/**
+ * Check if cookies are accepted
+ * @returns boolean
+ */
+export const areCookiesAccepted = (): boolean => {
+  return getCookieConsent() === 'accepted'
+}
+
+/**
+ * Reset cookie consent (useful for testing)
+ */
+export const resetCookieConsent = (): void => {
+  if (typeof window !== 'undefined') {
+    localStorage.removeItem('cookie-consent')
+  }
+}


### PR DESCRIPTION
This pull request introduces a user-facing cookie consent system and integrates it with Google Analytics (GA4) tracking. Users are now prompted to accept or decline cookies, and GA4 will only be initialized if consent is given. The implementation includes a new consent banner component with localization support, persistent consent storage, and conditional analytics loading.

**Cookie Consent System:**

* Added a new `CookieConsent` component that displays a banner prompting users to accept or decline cookies. Consent is stored in `localStorage`, and the banner supports multiple locales via a translations file. [[1]](diffhunk://#diff-7659132ce7c429ffad3e17f6f0ba3cefe50ded688b93a03b3ab621276182d796R1-R72) [[2]](diffhunk://#diff-c7126229c6f637656f02a96ecdb34fb0f6ff5c8ef2270a360f912149fd54eac2R1-R25)
* Implemented styled components for the consent banner, ensuring a responsive and accessible UI.

**Google Analytics Integration:**

* Created a `GoogleAnalytics` component that conditionally loads GA4 scripts only if cookies have been accepted. The component listens for consent changes and reloads the page to initialize tracking when consent is granted.
* Added utility functions in `cookieConsent.ts` to check, set, and reset cookie consent status.

**Application Integration:**

* Integrated the new `CookieConsent` and `GoogleAnalytics` components into the main application layout in `_app.tsx`, ensuring they are present on all pages. [[1]](diffhunk://#diff-88a36bc7a53bfa58c6f451464798d631d785160dfacfdaf9479be7a0b1d7e5e5R4-R5) [[2]](diffhunk://#diff-88a36bc7a53bfa58c6f451464798d631d785160dfacfdaf9479be7a0b1d7e5e5R15-R19)